### PR TITLE
Kategorien inkl. Unterkategorien löschen

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -17,6 +17,10 @@ cc_legend_categories_articles          = Kategorien und Artikel
 cc_config_checkbox_categories_articles = alle Kategorien und Artikel (in allen Sprachen) löschen
 cc_del_success_categories_articles     = Alle Kategorien und Artikel wurden gelöscht
 
+cc_legend_specific_category_articles      = Bestimmte Kategorie und Artikel inkl. Inhalte löschen
+cc_select_specific_category_articles      = Kategorie
+cc_del_success_specific_category_articles = Kategorie %s wurde gelöscht
+
 cc_legend_media                         = Medien
 cc_config_checkbox_media_cats           = alle Medienkategorien löschen
 cc_del_success_media_cats               = Alle Medienkategorien wurden gelöscht


### PR DESCRIPTION
Auf der Clear Content Seite gibt es nun ein Linkwidget. Man wählt den Artikel aus und die neue Funktion stellt dabei die Kategorie fest und löscht dann die zugehörige Kategorie als auch rekursiv alle Unterkategorien und Artikel.
Sollte der ausgewählte Artikel ein Rootartikel sein, dann wird nur der Artikel gelöscht.

Bitte nochmal gegenchecken, ob das alles so passt, am Besten mit was Unwichtigem :D