### PR TITLE
Zustimmung erforderlich

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -29,3 +29,4 @@ cc_config_checkbox_media                = alle Medien löschen
 cc_del_success_media                    = Alle Medien wurden gelöscht
 
 cc_config_clear                         = Inhalte unwiderruflich löschen
+cc_config_clear_confirmation            = Die Auswahl wird unwiderruflich gelöscht und kann nicht rückgängig gemacht werden. Ein Backup wird dringend empfohlen!

--- a/pages/config.php
+++ b/pages/config.php
@@ -257,7 +257,7 @@ $content .= $fragment->parse('core/form/checkbox.php');
 
 $formElements = [];
 $n = [];
-$n['field'] = '<button class="btn btn-save rex-form-aligned" type="submit" name="save" value="' . $this->i18n('cc_config_clear') . '">' . $this->i18n('cc_config_clear') . '</button>';
+$n['field'] = '<button class="btn btn-save rex-form-aligned" type="submit" name="save" value="' . $this->i18n('cc_config_clear') . '" data-confirm="' . $this->i18n('cc_config_clear_confirmation') . '">' . $this->i18n('cc_config_clear') . '</button>';
 $formElements[] = $n;
 
 


### PR DESCRIPTION
Bevor tatsächlich gelöscht wird, muss der Nutzer nun eine Abfrage bestätigen und erhält einen Hinweis, dass ein Backup angeraten wird.